### PR TITLE
Delete event overlays if removed

### DIFF
--- a/src/terraform-provider-signalform/signalform/dashboard.go
+++ b/src/terraform-provider-signalform/signalform/dashboard.go
@@ -414,14 +414,10 @@ func getPayloadDashboard(d *schema.ResourceData) ([]byte, error) {
 	}
 
 	overlays := d.Get("event_overlay").([]interface{})
-	if len(overlays) > 0 {
-		payload["eventOverlays"] = getDashboardEventOverlays(overlays)
-	}
+	payload["eventOverlays"] = getDashboardEventOverlays(overlays)
 
 	soverlays := d.Get("selected_event_overlay").([]interface{})
-	if len(soverlays) > 0 {
-		payload["selectedEventOverlays"] = getDashboardEventOverlays(soverlays)
-	}
+	payload["selectedEventOverlays"] = getDashboardEventOverlays(soverlays)
 
 	charts := getDashboardCharts(d)
 	column_charts := getDashboardColumns(d)


### PR DESCRIPTION
if you add an event overlay object, then terraform apply, then remove the object, then terraform apply - the second apply won't actually do anything and the event overlay will stay attached to the dashboard. we have to explicitly clear them.

r? @cory-stripe 