### PR TITLE
Histogram color theme options

### DIFF
--- a/docs/resources/time_chart.md
+++ b/docs/resources/time_chart.md
@@ -80,6 +80,8 @@ The following arguments are supported in the resource block:
     * `plot_type` - (Optional) The visualization style to use. Must be `"LineChart"`, `"AreaChart"`, `"ColumnChart"`, or `"Histogram"`. Chart level `plot_type` by default.
     * `value_unit` - (Optional) A unit to attach to this plot. Units support automatic scaling (eg thousands of bytes will be displayed as kilobytes).
     * `value_prefix`, `value_suffix` - (Optional) Arbitrary prefix/suffix to display with the value of this plot.
+* `histogram_options` - (Optional) Only used when `plot_type` is `"Histogram"`. Histogram specific options.
+    * `color_theme` - (Optional) Color to use : gray, blue, azure, navy, brown, orange, yellow, iris, magenta, pink, purple, violet, lilac, emerald, green, aquamarine, red, gold, greenyellow, chartreuse, jade
 * `legend_fields_to_hide` - (Optional) List of properties that should not be displayed in the chart legend (i.e. dimension names). All the properties are visible by default.
 * `on_chart_legend_dimension` - (Optional) Dimensions to show in the on-chart legend. On-chart legend is off unless a dimension is specified. Allowed: `"metric"`, `"plot_label"` and any dimension.
 * `show_event_lines` - (Optional) Whether vertical highlight lines should be drawn in the visualizations at times when events occurred. `false` by default.

--- a/src/terraform-provider-signalform/signalform/time_chart.go
+++ b/src/terraform-provider-signalform/signalform/time_chart.go
@@ -30,6 +30,30 @@ var PaletteColors = map[string]int{
 	"aquamarine": 15,
 }
 
+var FullPaletteColors = map[string]int{
+	"gray":        0,
+	"blue":        1,
+	"azure":       2,
+	"navy":        3,
+	"brown":       4,
+	"orange":      5,
+	"yellow":      6,
+	"magenta":     7,
+	"purple":      8,
+	"pink":        9,
+	"violet":      10,
+	"lilac":       11,
+	"iris":        12,
+	"emerald":     13,
+	"green":       14,
+	"aquamarine":  15,
+	"red":         16,
+	"gold":        17,
+	"greenyellow": 18,
+	"chartreuse":  19,
+	"jade":        20,
+}
+
 func resourceAxisMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
@@ -329,6 +353,21 @@ func timeChartResource() *schema.Resource {
 				Description:  "(LineChart by default) The default plot display style for the visualization. Must be \"LineChart\", \"AreaChart\", \"ColumnChart\", or \"Histogram\"",
 				ValidateFunc: validatePlotTypeTimeChart,
 			},
+			"histogram_options": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Options specific to Histogram charts",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"color_theme": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Base color theme to use for the graph.",
+							ValidateFunc: validateFullPaletteColors,
+						},
+					},
+				},
+			},
 			"viz_options": &schema.Schema{
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -590,6 +629,17 @@ func getTimeChartOptions(d *schema.ResourceData) map[string]interface{} {
 			viz["areaChartOptions"] = dataMarkersOption
 		} else if chartType == "LineChart" {
 			viz["lineChartOptions"] = dataMarkersOption
+		} else if chartType == "Histogram" {
+			histogramChartOptions := make(map[string]interface{})
+			if histogram_options, ok := d.GetOk("histogram_options"); ok {
+				hOptions := histogram_options.(*schema.Set).List()[0].(map[string]interface{})
+				if color_theme, ok := hOptions["color_theme"].(string); ok {
+					if elem, ok := FullPaletteColors[color_theme]; ok {
+						histogramChartOptions["colorThemeIndex"] = elem
+						viz["histogramChartOptions"] = histogramChartOptions
+					}
+				}
+			}
 		}
 	} else {
 		viz["lineChartOptions"] = dataMarkersOption

--- a/src/terraform-provider-signalform/signalform/util.go
+++ b/src/terraform-provider-signalform/signalform/util.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 const (
@@ -293,6 +294,19 @@ func validatePerSignalColor(v interface{}, k string) (we []string, errors []erro
 	if _, ok := PaletteColors[value]; !ok {
 		keys := make([]string, 0, len(PaletteColors))
 		for k := range PaletteColors {
+			keys = append(keys, k)
+		}
+		joinedColors := strings.Join(keys, ",")
+		errors = append(errors, fmt.Errorf("%s not allowed; must be either %s", value, joinedColors))
+	}
+	return
+}
+
+func validateFullPaletteColors(v interface{}, k string) (we []string, errors []error) {
+	value := v.(string)
+	if _, ok := FullPaletteColors[value]; !ok {
+		keys := make([]string, 0, len(FullPaletteColors))
+		for k := range FullPaletteColors {
 			keys = append(keys, k)
 		}
 		joinedColors := strings.Join(keys, ",")

--- a/src/terraform-provider-signalform/signalform/util_test.go
+++ b/src/terraform-provider-signalform/signalform/util_test.go
@@ -2,10 +2,11 @@ package signalform
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSendRequestSuccess(t *testing.T) {
@@ -80,6 +81,16 @@ func TestValidateSortByAscending(t *testing.T) {
 func TestValidateSortByDescending(t *testing.T) {
 	_, errors := validateSortBy("-foo", "sort_by")
 	assert.Equal(t, 0, len(errors))
+}
+
+func TestValidateFullPaletteColors(t *testing.T) {
+	_, errors := validateFullPaletteColors("chartreuse", "color_theme")
+	assert.Equal(t, 0, len(errors))
+}
+
+func TestValidateFullPaletteColorsFail(t *testing.T) {
+	_, errors := validateFullPaletteColors("fart", "color_theme")
+	assert.Equal(t, 1, len(errors))
 }
 
 func TestValidateSortByNoDirection(t *testing.T) {


### PR DESCRIPTION
Zanker tried to send this in #12 but I ruined it and had to recreate it a few times. This works.

I verified this locally by changing the definition of a chart and running `terraform plan`:

Input:
```
+  histogram_options {
+    color_theme = "violet"
+  }
```

Output:
```
~ module.dashboards.signalform_time_chart.chart_bapirubyvmstatus_gc_time_p
    histogram_options.#:                        "0" => "1"
    histogram_options.2693793231.color_theme:   "" => "violet"
```

r? @sjung-stripe 
cc @zanker-stripe @stripe/observability 